### PR TITLE
Updates vlm for more recent gcc and libcrypt

### DIFF
--- a/configure
+++ b/configure
@@ -5220,11 +5220,11 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char encrypt ();
+char crypt ();
 int
 main ()
 {
-return encrypt ();
+return crypt ();
   ;
   return 0;
 }
@@ -8914,4 +8914,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_CHECK_LIB([X11], [XKeysymToKeycode],[],
 AC_CHECK_LIB([xcb], [xcb_disconnect],[:])
 AC_CHECK_LIB([c], [fprintf],[],
 		    [AC_MSG_ERROR([you need libc to compile the vlm])])
-AC_CHECK_LIB([crypt], [encrypt],[],
+AC_CHECK_LIB([crypt], [crypt],[],
 		    [AC_MSG_ERROR([you need libcrypt to compile the vlm])])
 AC_CHECK_LIB([dl], [dlopen],[],
 		    [AC_MSG_ERROR([you need libdl to compile the vlm])])
@@ -84,7 +84,7 @@ AC_ARG_ENABLE([debug],
 	 [enable debuggeable code (-g2) (default=no)]),
 	[],
 	[enable_debug=no])
-if ! test -z $enable_debug && 
+if ! test -z $enable_debug &&
     test "x$enable_debug" = "xyes"
 then
     AS_ECHO(["enabling debugging"])
@@ -104,7 +104,7 @@ if ! test -z $enable_fast &&
 then
     AS_ECHO(["disabling optimization for speed"])
     AX_CFLAGS_GCC_OPTION(-O2)
-else	
+else
     AS_ECHO(["enabling optimization for speed"])
     AX_CFLAGS_GCC_OPTION(-Ofast)
 fi
@@ -123,7 +123,7 @@ if ! test -z $enable_genera &&
     test "x$enable_genera" = "xno"
 then
     AS_ECHO(["disabling compilation for genera"])
-else	
+else
     AS_ECHO(["enabling compilation for genera"])
     CPPFLAGS+=" -DGENERA -DAUTOSTART"
 fi
@@ -152,7 +152,7 @@ if ! test -z $enable_debug_network &&
 then
     AS_ECHO(["enabling network debugging"])
     CPPFLAGS+=" -DDEBUG_NETWORK=1"
-else	
+else
     AS_ECHO(["disabling network debugging"])
 fi
 
@@ -169,7 +169,7 @@ then
     then
 	AS_ECHO(["enabling IP network debugging"])
 	CPPFLAGS+=" -DDEBUG_IP=1"
-    else	
+    else
 	AS_ECHO(["disabling IP network debugging"])
     fi
 else
@@ -193,7 +193,7 @@ then
     then
 	AS_ECHO(["enabling CHAOS network debugging"])
 	CPPFLAGS+=" -DDEBUG_CHAOS=1"
-    else	
+    else
 	AS_ECHO(["disabling CHAOS network debugging"])
     fi
 else
@@ -217,7 +217,7 @@ then
     then
 	AS_ECHO(["enabling ARP network debugging"])
 	CPPFLAGS+=" -DDEBUG_ARP=1"
-    else	
+    else
 	AS_ECHO(["disabling ARP network debugging"])
     fi
 else
@@ -242,7 +242,7 @@ then
 	AC_MSG_WARN([enabling IP network debugging to enable ICMP debugging])
 	AS_ECHO(["enabling ICMP network debugging"])
 	CPPFLAGS+=" -DDEBUG_IP -DDEBUG_ICMP=1"
-    else	
+    else
 	AS_ECHO(["disabling ICMP network debugging"])
     fi
 else
@@ -268,7 +268,7 @@ fi
 
 AC_CONFIG_FILES([Makefile
 	src/Makefile
-	emulator/Makefile 
-	life-support/Makefile 
+	emulator/Makefile
+	life-support/Makefile
 	stub/Makefile])
 AC_OUTPUT

--- a/stub/process.lisp
+++ b/stub/process.lisp
@@ -780,7 +780,7 @@
   (or (eq str 'ocp) (eq str 'ecp) (eq str 'iCP) (equal str "iCP")))
 
 (defun cacheline-ptr-str (ptr)
-  (if (or (eq ptr 'iCP) (equal ptr "iCP")) 
+  (if (or (eq ptr 'iCP) (equal ptr "iCP"))
       "iCP"
     (string-downcase ptr)))
 
@@ -1514,25 +1514,25 @@
 	(FBEQ
 	 (check-comment arg3)
 	 (format destination "  if (FLTU64(~A, ~A) == 0.0)~%    goto ~A;~%"
-		 (regnum (fixarg arg1)) (fixarg arg1) 
+		 (regnum (fixarg arg1)) (fixarg arg1)
 		 (gotolabel arg2)))
 
 	(FBLT
 	 (check-comment arg3)
 	 (format destination "  if (FLTU64(~A, ~A) < 0.0)~%    goto ~A;~%"
-		 (regnum (fixarg arg1)) (fixarg arg1) 
+		 (regnum (fixarg arg1)) (fixarg arg1)
 		 (gotolabel arg2)))
 
 	(FBGT
 	 (check-comment arg3)
 	 (format destination "  if (FLTU64(~A, ~A) > 0.0)~%    goto ~A;~%"
-		 (regnum (fixarg arg1)) (fixarg arg1) 
+		 (regnum (fixarg arg1)) (fixarg arg1)
 		 (gotolabel arg2)))
 
 	(FBNE
 	 (check-comment arg3)
 	 (format destination "  if (FLTU64(~A, ~A) != 0.0)~%    goto ~A;~%"
-		 (regnum (fixarg arg1)) (fixarg arg1) 
+		 (regnum (fixarg arg1)) (fixarg arg1)
 		 (gotolabel arg2)))
 
 	(FCMOVGT
@@ -1556,7 +1556,7 @@
 
 	(JMP
 	 (check-comment arg4)
-	 (format destination "    goto *~A; /* jmp */~%"
+	 (format destination "    goto *((void *) ~A); /* jmp */~%"
 		 (fixarg arg2)))
 
 	(JSR
@@ -1679,7 +1679,7 @@
 	     (format destination "  LDS(~A, ~A, *(u32 *)~A );~%"
 		     (regnum (fixarg arg1)) (fixarg arg1) (fixarg arg3))
 	   (format destination "  LDS(~A, ~A, ~A->~A);~%"
-		   (regnum (fixarg arg1)) 
+		   (regnum (fixarg arg1))
 		   (fixarg arg1) (structptr arg3) (fixarg arg2))))
 
 	(LDT
@@ -1690,7 +1690,7 @@
 	     (format destination "  LDT(~A, ~A, *(u32 *)~A );~%"
 		     (regnum (fixarg arg1)) (fixarg arg1) (fixarg arg3))
 	   (format destination "  LDT(~A, ~A, ~A->~A);~%"
-		   (regnum (fixarg arg1)) 
+		   (regnum (fixarg arg1))
 		   (fixarg arg1) (structptr arg3) (fixarg arg2))))
 
 	(STS
@@ -1860,7 +1860,7 @@
 	 (fixarg arg2)
 	 (fixarg arg3))
 	 (setq *do-check-ratquo* t))
-	
+
 	(LIBMFLOOR
 	 (format destination
 		 "  /* use libc function floor for rounding-mode :down */~%")
@@ -1988,7 +1988,7 @@
 
 	(SRA
 	 (check-comment arg4)
-	 (setq shiftarg 
+	 (setq shiftarg
 	       (if (numberp arg2) (logand arg2 63)
 		 (format nil "(~A & 63)" (fixarg arg2))))
 	 (format destination "  ~A = (s64)~A >> ~A;~%"
@@ -1996,7 +1996,7 @@
 
 	(SRL
 	 (check-comment arg4)
-	 (setq shiftarg 
+	 (setq shiftarg
 	       (if (numberp arg2) (logand arg2 63)
 		 (format nil "(~A & 63)" (fixarg arg2))))
 	 (format destination "  ~A = ~A >> ~A;~%"
@@ -2004,7 +2004,7 @@
 
 	(SLL
 	 (check-comment arg4)
-	 (setq shiftarg 
+	 (setq shiftarg
 	       (if (numberp arg2) (logand arg2 63)
 		 (format nil "(~A & 63)" (fixarg arg2))))
 	 (format destination "  ~A = ~A << ~A;~%"
@@ -2159,7 +2159,7 @@
 
 	(RET
 	 (if (eq arg1 'zero)
-	     (format destination "  goto *~A; /* ret */~%" (fixarg arg2))
+	     (format destination "  goto *((void *) ~A); /* ret */~%" (fixarg arg2))
 	   (format t "*** RET w/arg1")))
 
 	(TAGTYPE
@@ -2190,7 +2190,7 @@
 		 (equal (ext:substring arg1 0 5) "#ifnd")
 		 (equal (ext:substring arg1 0 4) "#end"))
 	     (format destination "~A~%" arg1)))
-	     
+
 	(otherwise
 	 (format t "***UNKNOWN FORM: ~S~%" form))
 
@@ -2222,7 +2222,7 @@
 	(c-header tfs sourcefilename)
 	(do ((form (read sfs nil :eof) (read sfs nil :eof)))
 	    ((eq form :eof) nil)
-	  (when (consp form) 
+	  (when (consp form)
 	    (process-asm-form form tfs)))
 	(c-trailer tfs sourcefilename)))))
 


### PR DESCRIPTION
1. `configure` checks for the presences of `libcrypt.so` by testing for the existence of `encrypt()`, but `encrypt()` no longer has a default .so version. However, only `life-support/unixcrypt.c` depends on `<crypt.h>` and rather than calling `encrypt()`, it calls `crypt()` which does have a default `.so` version. Changing this allows `configure` to discover the presence of `libcrypt.so`
2. Newer versions of gcc require pointer-typed values for computed `goto`. This casts the `u64` pointer values to `void*` for the goto instructions for the C implementations of `jmp` and `ret` which are e.g. `goto *r0` calls into `goto *((void*) r0)` calls